### PR TITLE
Add a control signal compensation to avoid abrupt command changes

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -92,7 +92,9 @@ bool Task::configureHook()
     //build and set the velocity twist matrix
     cVb.buildFrom(cMb);
     task.set_cVe(cVb);
-
+    
+    exp_decay_factor = _exp_decay_factor.get();
+    task.setMu(exp_decay_factor);
     return true;
 }
 
@@ -150,7 +152,7 @@ void Task::updateHook()
     vpColVector v;
     task.set_cVe(cVb);
 
-    if(_exp_decay_factor.get() == 0)
+    if(exp_decay_factor == 0)
         v = task.computeControlLaw();
     else
     {
@@ -164,7 +166,6 @@ void Task::updateHook()
             elapsed_time.fromSeconds(0);
         }
 
-        task.setMu(_exp_decay_factor.get());
         v = task.computeControlLaw(elapsed_time.toSeconds());
     }
 
@@ -465,3 +466,10 @@ bool Task::setDesired_target(std::string const &value)
     return true;
 }
 
+bool Task::setExp_decay_factor(double value)
+{
+    exp_decay_factor = value;
+    task.setMu(exp_decay_factor);
+
+    return (visp::TaskBase::setExp_decay_factor(value));
+}

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -43,6 +43,7 @@ namespace visp{
         visp::expectedInputs expected_inputs;
         visp::controllerState ctrl_state;
         base::LinearAngular6DCommand setpoint;
+        base::Time start_time;
 
         vpCameraParameters cam_cal;
         vpServo task;

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -44,6 +44,7 @@ namespace visp{
         visp::controllerState ctrl_state;
         base::LinearAngular6DCommand setpoint;
         base::Time start_time;
+        double exp_decay_factor;
 
         vpCameraParameters cam_cal;
         vpServo task;
@@ -140,6 +141,15 @@ namespace visp{
          *  \param string containing the desired target's identifier
          */
         virtual bool setDesired_target(std::string const &value);
+
+        /** Update the exponential decay factor. A value that 
+         *  affects the velocity of the control compensation decay.
+         *  A big value makes the compensation less effective. A
+         *  sugested initial value is 4. 
+         *  \param time constant for the control
+         *         exponential decay.
+         */
+        virtual bool setExp_decay_factor(double value);
 
         public:
         /** TaskContext constructor for Task

--- a/visp.orogen
+++ b/visp.orogen
@@ -44,7 +44,7 @@ needs_configuration
     # in the beginning of the task.
     # Set zero to deactivate this term. If used, a suggested initial
     # value is 4.
-    property("exp_decay_factor", "double", 0)
+    property("exp_decay_factor", "double", 0).dynamic
     # Time limit without markers to reset the time on the exponential decay
     # term. NOTE: This is invalid if "exp_decay_factor == 0"
     property("exp_timeout", "/base/Time")

--- a/visp.orogen
+++ b/visp.orogen
@@ -36,6 +36,19 @@ needs_configuration
     # provider
     property("scaling", "double", 1.0)
 
+    # Given a control law defined by v(t) = A(t)*error(t)-A(0)*error(0)*ext(-u*t)
+    # This property is the time constant "u" that defines the velocity of the
+    # exponential decay. It means that the impact of the term is bigger
+    # when the exp_decay_factor is smaller.
+    # This is used to avoid abrupt changes in the velocities output
+    # in the beginning of the task.
+    # Set zero to deactivate this term. If used, a suggested initial
+    # value is 4.
+    property("exp_decay_factor", "double", 0)
+    # Time limit without markers to reset the time on the exponential decay
+    # term. NOTE: This is invalid if "exp_decay_factor == 0"
+    property("exp_timeout", "/base/Time")
+
     # Position setpoint in respect to the marker frame
     input_port "cmd_in", "/base/LinearAngular6DCommand"
     # Input data to the controlller


### PR DESCRIPTION
Improve the tradicional control law v(t) = A*error(t) by
adding a exponetial term that starts with the value when
the error is zero and decay with the time. 
v(t) = A*error(t)-A*error(0)*exp(-u*t) . This avoids
abrupt changes on the velocities command on the beginning
of the task, where the error is big. It also allow to use
higher static gain, since the soft-velocity-changing will
reduce the image motion blur.