### PR TITLE
remove the default values for setpoint

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -197,10 +197,6 @@ void Task::updateFeaturesHVS(Points const &corners, vpHomogeneousMatrix const &c
     //compute the "quality" of the result
     ctrl_state.residual = pose.computeResidual(cMo);
 
-    // apply a rotation around the z on the camera frame
-    vpHomogeneousMatrix rot(0, 0, 0, 0, 0, vpMath::rad(rotation_around_z));
-    cMo = cMo * rot;
-
     /**
      *  Update Feature 1 - p
      */
@@ -260,25 +256,16 @@ void Task::updateFeaturesHVS(Points const &corners, vpHomogeneousMatrix const &c
 
 vpHomogeneousMatrix Task::updateDesiredPose(base::LinearAngular6DCommand setpoint)
 {
-    // Set the input command to their default values when they are not expected.
-    // This is required to create a valid vpHomogeneousMatrix, since non-expected
-    // inputs are NaN.
-    // Given that the object frame's z-axis points to the oposite side of the body
-    // frame's x-axis. The object's x and y axis are in such way that in order
-    // to have a vehicle stable in "d" meters in front of the object, the desired
-    // posistion has to be: {x=d, y=0, z=0, roll=-pi/2, pitch=-pi/2, yaw=0}.
-    static const double arr[6] = {0, 0, 0, -M_PI_2, 0, -M_PI_2};
-    std::vector<double> default_linear_values(&arr[0], &arr[0]+3);
-    std::vector<double> default_angular_values(&arr[3], &arr[3]+3);
-
-    for (int i = 0; i < 3; ++i)
+    for(int i = 0; i < 3; i++)
     {
-        if (!expected_inputs.linear[i])
-            setpoint.linear[i] = default_linear_values[i];
+        if (base::isNaN(setpoint.linear[i]) || base::isNaN(setpoint.angular[i]))
+        {
 
-        if (!expected_inputs.angular[i])
-            setpoint.angular[i] = default_angular_values[i];
+            throw std::invalid_argument(std::string("At least one of the input commands are NaN.") +
+                                        std::string("Visp expects all commands as setpoint."));
+        }
     }
+
 
     //create a vpHomogeneousMatrix of the object desired position wrt body (bdMo)
     vpTranslationVector bdto(setpoint.linear[0],
@@ -287,11 +274,8 @@ vpHomogeneousMatrix Task::updateDesiredPose(base::LinearAngular6DCommand setpoin
     vpRotationMatrix bdRo(vpRzyxVector(setpoint.angular[2],
                                        setpoint.angular[1],
                                        setpoint.angular[0]));
-
-    //vpRotationMatrix teste(0,0,setpoint.angular[2]);
-    //bdRo = teste*bdRo;
     vpHomogeneousMatrix bdMo(bdto, bdRo);
-
+    
     //bdMo is the desired pose of the object in the body frame
     //cdMo is the desired pose of the object in the camera frame
     //cMb is the transformation matrix of the body in the camera frame
@@ -424,8 +408,6 @@ void Task::updateTargetParameters(std::string const &desired_target)
         {
             //update the size of the object
             setObjectSize(target_list[i].width, target_list[i].height);
-            //update the rotation
-            rotation_around_z = target_list[i].rotation_around_z;
             return;
         }
     }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -267,7 +267,7 @@ vpHomogeneousMatrix Task::updateDesiredPose(base::LinearAngular6DCommand setpoin
     // frame's x-axis. The object's x and y axis are in such way that in order
     // to have a vehicle stable in "d" meters in front of the object, the desired
     // posistion has to be: {x=d, y=0, z=0, roll=-pi/2, pitch=-pi/2, yaw=0}.
-    static const double arr[6] = {0, 0, 0, -M_PI_2, -M_PI_2, 0};
+    static const double arr[6] = {0, 0, 0, -M_PI_2, 0, -M_PI_2};
     std::vector<double> default_linear_values(&arr[0], &arr[0]+3);
     std::vector<double> default_angular_values(&arr[3], &arr[3]+3);
 
@@ -284,9 +284,12 @@ vpHomogeneousMatrix Task::updateDesiredPose(base::LinearAngular6DCommand setpoin
     vpTranslationVector bdto(setpoint.linear[0],
                              setpoint.linear[1],
                              setpoint.linear[2]);
-    vpRotationMatrix bdRo(vpRxyzVector(setpoint.angular[0],
+    vpRotationMatrix bdRo(vpRzyxVector(setpoint.angular[2],
                                        setpoint.angular[1],
-                                       setpoint.angular[2]));
+                                       setpoint.angular[0]));
+
+    //vpRotationMatrix teste(0,0,setpoint.angular[2]);
+    //bdRo = teste*bdRo;
     vpHomogeneousMatrix bdMo(bdto, bdRo);
 
     //bdMo is the desired pose of the object in the body frame

--- a/test/static_transforms.rb
+++ b/test/static_transforms.rb
@@ -1,0 +1,6 @@
+### Sensors
+
+## camera in body frame
+static_transform Eigen::Quaternion.from_euler(Eigen::Vector3.new(-1.571, 0, -1.571), 2, 1, 0),
+    Eigen::Vector3.new(0.979, 0.131, -0.221),
+    "camera" => "body"

--- a/test/test.rb
+++ b/test/test.rb
@@ -1,14 +1,13 @@
-require 'pry-byebug'
+require 'pry'
 require 'minitest/spec'
 require 'orocos/test/component'
 require 'minitest/autorun'
-require "transformer/runtime"
+
 
 describe 'visp::Task checking' do
   include Orocos::Test::Component
   start 'task', 'visp::Task' => 'task'
   reader 'task', 'cmd_out', :attr_name => 'cmd_out'
-  reader 'task', 'controller_state', :attr_name => 'controller_state'
   writer 'task', 'cmd_in', :attr_name => 'cmd_in'
   writer 'task', 'marker_corners', :attr_name => 'marker_corners'
 
@@ -49,65 +48,65 @@ describe 'visp::Task checking' do
 
 
 
-  #it 'if no corners are informed' do
-  #  task.apply_conf_file("visp::Task.yml")
-  #  task.configure
-  #  task.start
-  #  
-  #  #writing the setpoint
-  #  setpoint_samples = create_setpoint(1, 1, 1, 0, 0, 0)
-  #  cmd_in.write setpoint_samples
+  it 'if no corners are informed' do
+    task.apply_conf_file("visp::Task.yml")
+    task.configure
+    task.start
+    
+    #writing the setpoint
+    setpoint_samples = create_setpoint(1, 1, 1, 0, 0, 0)
+    cmd_in.write setpoint_samples
 
-  #  assert_task_state(task, :WAITING_CORNERS)
-  #end
+    assert_task_state(task, :WAITING_CORNERS)
+  end
 
-  #it 'if no setpoint is informed' do
-  #  task.apply_conf_file("visp::Task.yml")
-  #  task.configure
-  #  task.start
+  it 'if no setpoint is informed' do
+    task.apply_conf_file("visp::Task.yml")
+    task.configure
+    task.start
 
-  #  #writing corners
-  #  corners_samples = create_corners([1400, 600], [1400, 400], [1600, 400], [1600, 600])
-  #  marker_corners.write corners_samples
-  #  assert_task_state(task, :WAITING_SETPOINT)
-  #end
+    #writing corners
+    corners_samples = create_corners([1400, 600], [1400, 400], [1600, 400], [1600, 600])
+    marker_corners.write corners_samples
+    assert_task_state(task, :WAITING_SETPOINT)
+  end
 
-  #it 'if there is corners and setpoint' do
-  #  task.apply_conf_file("visp::Task.yml")
-  #  task.configure
-  #  task.start
+  it 'if there is corners and setpoint' do
+    task.apply_conf_file("visp::Task.yml")
+    task.configure
+    task.start
 
-  #  corners_samples = create_corners([1400, 600], [1400, 400], [1600, 400], [1600, 600])
-  #  setpoint_samples = create_setpoint(1, 1, 1, 0, 0, 0)
+    corners_samples = create_corners([1400, 600], [1400, 400], [1600, 400], [1600, 600])
+    setpoint_samples = create_setpoint(1, 1, 1, 0, 0, 0)
 
-  #  #writing ports
-  #  #NOTE: Since the component is triggered by the marker_corners input port
-  #  #it has to be written after the setpoint
-  #  cmd_in.write setpoint_samples
-  #  marker_corners.write corners_samples
-  #  assert_task_state(task, :CONTROLLING)
-  #end
+    #writing ports
+    #NOTE: Since the component is triggered by the marker_corners input port
+    #it has to be written after the setpoint
+    cmd_in.write setpoint_samples
+    marker_corners.write corners_samples
+    assert_task_state(task, :CONTROLLING)
+  end
 
-  #it 'if multiple state changes works as expected' do
-  #  task.apply_conf_file("visp::Task.yml")
-  #  task.configure
-  #  task.start
+  it 'if multiple state changes works as expected' do
+    task.apply_conf_file("visp::Task.yml")
+    task.configure
+    task.start
 
-  #  corners_samples = create_corners([1400, 600], [1400, 400], [1600, 400], [1600, 600])
-  #  setpoint_samples = create_setpoint(1, 1, 1, 0, 0, 0)
+    corners_samples = create_corners([1400, 600], [1400, 400], [1600, 400], [1600, 600])
+    setpoint_samples = create_setpoint(1, 1, 1, 0, 0, 0)
 
-  #  assert_task_state(task, :WAITING_CORNERS)
+    assert_task_state(task, :WAITING_CORNERS)
 
-  #  marker_corners.write corners_samples
-  #  assert_task_state(task, :WAITING_SETPOINT)
+    marker_corners.write corners_samples
+    assert_task_state(task, :WAITING_SETPOINT)
 
-  #  #NOTE: Since the component is triggered by the marker_corners input port
-  #  #it has to be written after the setpoint
-  #  cmd_in.write setpoint_samples
-  #  marker_corners.write corners_samples
-  #  assert_task_state(task, :CONTROLLING)
+    #NOTE: Since the component is triggered by the marker_corners input port
+    #it has to be written after the setpoint
+    cmd_in.write setpoint_samples
+    marker_corners.write corners_samples
+    assert_task_state(task, :CONTROLLING)
 
-  #end
+  end
 
   it 'if visual feature are in the first quadrant' do
     task.apply_conf_file("visp::Task.yml")
@@ -192,54 +191,5 @@ describe 'visp::Task checking' do
       "the result is not the expected when the object is on the third quadrant, values
       are #{data.linear[0]}, #{data.linear[1]}, #{data.linear[2]}")
   end
-  
-  it 'if it apply the transformation correctly' do
-    Orocos.conf.load_dir('.')
-    Orocos.conf.apply(task,['default'])
 
-    Orocos.transformer.load_conf("static_transforms.rb")
-    Orocos.transformer.setup(task)
-
-    #increase the gain, so the differences is better noticed
-    task.gain = 0.2
-    task.configure
-    task.start
-
-    #creating the corner_samples
-    corners_samples = create_corners([400, 1600], [400, 1400], [600, 1400], [600, 1600])
-    #creating setpoint
-    ang30 = 30*3.1417/180
-    ang90 = 90*3.1417/180
-    setpoint_samples = create_setpoint(2, 0, 0, 0, 0, -ang90)
-
-    #NOTE: Since the component is triggered by the marker_corners input port
-    #it has to be written after the setpoint
-    cmd_in.write setpoint_samples
-    marker_corners.write corners_samples
-    #data_base = assert_has_one_new_sample cmd_out, 1
-    data_base = assert_has_one_new_sample controller_state, 1
-    vel_base = assert_has_one_new_sample cmd_out, 1
-    
-    #write  a setpoint of 30 degress to yaw.
-    setpoint_samples = create_setpoint(2, 0, 0, 0, 0, -ang90+ang30)
-    cmd_in.write setpoint_samples
-    marker_corners.write corners_samples
-    #data = assert_has_one_new_sample cmd_out, 1
-    data = assert_has_one_new_sample controller_state, 1
-    vel = assert_has_one_new_sample cmd_out, 1
-
-    puts "vel_base.angular #{vel_base.angular[2]}"
-    puts "vel.angular #{vel.angular[2]}"
-    
-    puts "data_base.angular #{data_base.desired_pose.orientation.roll}"
-    puts "data_base.angular #{data_base.desired_pose.orientation.pitch}"
-    puts "data_base.angular #{data_base.desired_pose.orientation.yaw}"
-
-    puts "data.angular #{data.desired_pose.orientation.roll}"
-    puts "data.angular #{data.desired_pose.orientation.pitch}"
-    puts "data.angular #{data.desired_pose.orientation.yaw}"
-
-    assert((data.angular[2] < 0))
-    assert((data_base.angular[2] - data.angular[2]) > 0.01)
-  end
 end

--- a/test/test.rb
+++ b/test/test.rb
@@ -1,13 +1,14 @@
-require 'pry'
+require 'pry-byebug'
 require 'minitest/spec'
 require 'orocos/test/component'
 require 'minitest/autorun'
-
+require "transformer/runtime"
 
 describe 'visp::Task checking' do
   include Orocos::Test::Component
   start 'task', 'visp::Task' => 'task'
   reader 'task', 'cmd_out', :attr_name => 'cmd_out'
+  reader 'task', 'controller_state', :attr_name => 'controller_state'
   writer 'task', 'cmd_in', :attr_name => 'cmd_in'
   writer 'task', 'marker_corners', :attr_name => 'marker_corners'
 
@@ -48,65 +49,65 @@ describe 'visp::Task checking' do
 
 
 
-  it 'if no corners are informed' do
-    task.apply_conf_file("visp::Task.yml")
-    task.configure
-    task.start
-    
-    #writing the setpoint
-    setpoint_samples = create_setpoint(1, 1, 1, 0, 0, 0)
-    cmd_in.write setpoint_samples
+  #it 'if no corners are informed' do
+  #  task.apply_conf_file("visp::Task.yml")
+  #  task.configure
+  #  task.start
+  #  
+  #  #writing the setpoint
+  #  setpoint_samples = create_setpoint(1, 1, 1, 0, 0, 0)
+  #  cmd_in.write setpoint_samples
 
-    assert_task_state(task, :WAITING_CORNERS)
-  end
+  #  assert_task_state(task, :WAITING_CORNERS)
+  #end
 
-  it 'if no setpoint is informed' do
-    task.apply_conf_file("visp::Task.yml")
-    task.configure
-    task.start
+  #it 'if no setpoint is informed' do
+  #  task.apply_conf_file("visp::Task.yml")
+  #  task.configure
+  #  task.start
 
-    #writing corners
-    corners_samples = create_corners([1400, 600], [1400, 400], [1600, 400], [1600, 600])
-    marker_corners.write corners_samples
-    assert_task_state(task, :WAITING_SETPOINT)
-  end
+  #  #writing corners
+  #  corners_samples = create_corners([1400, 600], [1400, 400], [1600, 400], [1600, 600])
+  #  marker_corners.write corners_samples
+  #  assert_task_state(task, :WAITING_SETPOINT)
+  #end
 
-  it 'if there is corners and setpoint' do
-    task.apply_conf_file("visp::Task.yml")
-    task.configure
-    task.start
+  #it 'if there is corners and setpoint' do
+  #  task.apply_conf_file("visp::Task.yml")
+  #  task.configure
+  #  task.start
 
-    corners_samples = create_corners([1400, 600], [1400, 400], [1600, 400], [1600, 600])
-    setpoint_samples = create_setpoint(1, 1, 1, 0, 0, 0)
+  #  corners_samples = create_corners([1400, 600], [1400, 400], [1600, 400], [1600, 600])
+  #  setpoint_samples = create_setpoint(1, 1, 1, 0, 0, 0)
 
-    #writing ports
-    #NOTE: Since the component is triggered by the marker_corners input port
-    #it has to be written after the setpoint
-    cmd_in.write setpoint_samples
-    marker_corners.write corners_samples
-    assert_task_state(task, :CONTROLLING)
-  end
+  #  #writing ports
+  #  #NOTE: Since the component is triggered by the marker_corners input port
+  #  #it has to be written after the setpoint
+  #  cmd_in.write setpoint_samples
+  #  marker_corners.write corners_samples
+  #  assert_task_state(task, :CONTROLLING)
+  #end
 
-  it 'if multiple state changes works as expected' do
-    task.apply_conf_file("visp::Task.yml")
-    task.configure
-    task.start
+  #it 'if multiple state changes works as expected' do
+  #  task.apply_conf_file("visp::Task.yml")
+  #  task.configure
+  #  task.start
 
-    corners_samples = create_corners([1400, 600], [1400, 400], [1600, 400], [1600, 600])
-    setpoint_samples = create_setpoint(1, 1, 1, 0, 0, 0)
+  #  corners_samples = create_corners([1400, 600], [1400, 400], [1600, 400], [1600, 600])
+  #  setpoint_samples = create_setpoint(1, 1, 1, 0, 0, 0)
 
-    assert_task_state(task, :WAITING_CORNERS)
+  #  assert_task_state(task, :WAITING_CORNERS)
 
-    marker_corners.write corners_samples
-    assert_task_state(task, :WAITING_SETPOINT)
+  #  marker_corners.write corners_samples
+  #  assert_task_state(task, :WAITING_SETPOINT)
 
-    #NOTE: Since the component is triggered by the marker_corners input port
-    #it has to be written after the setpoint
-    cmd_in.write setpoint_samples
-    marker_corners.write corners_samples
-    assert_task_state(task, :CONTROLLING)
+  #  #NOTE: Since the component is triggered by the marker_corners input port
+  #  #it has to be written after the setpoint
+  #  cmd_in.write setpoint_samples
+  #  marker_corners.write corners_samples
+  #  assert_task_state(task, :CONTROLLING)
 
-  end
+  #end
 
   it 'if visual feature are in the first quadrant' do
     task.apply_conf_file("visp::Task.yml")
@@ -191,5 +192,54 @@ describe 'visp::Task checking' do
       "the result is not the expected when the object is on the third quadrant, values
       are #{data.linear[0]}, #{data.linear[1]}, #{data.linear[2]}")
   end
+  
+  it 'if it apply the transformation correctly' do
+    Orocos.conf.load_dir('.')
+    Orocos.conf.apply(task,['default'])
 
+    Orocos.transformer.load_conf("static_transforms.rb")
+    Orocos.transformer.setup(task)
+
+    #increase the gain, so the differences is better noticed
+    task.gain = 0.2
+    task.configure
+    task.start
+
+    #creating the corner_samples
+    corners_samples = create_corners([400, 1600], [400, 1400], [600, 1400], [600, 1600])
+    #creating setpoint
+    ang30 = 30*3.1417/180
+    ang90 = 90*3.1417/180
+    setpoint_samples = create_setpoint(2, 0, 0, 0, 0, -ang90)
+
+    #NOTE: Since the component is triggered by the marker_corners input port
+    #it has to be written after the setpoint
+    cmd_in.write setpoint_samples
+    marker_corners.write corners_samples
+    #data_base = assert_has_one_new_sample cmd_out, 1
+    data_base = assert_has_one_new_sample controller_state, 1
+    vel_base = assert_has_one_new_sample cmd_out, 1
+    
+    #write  a setpoint of 30 degress to yaw.
+    setpoint_samples = create_setpoint(2, 0, 0, 0, 0, -ang90+ang30)
+    cmd_in.write setpoint_samples
+    marker_corners.write corners_samples
+    #data = assert_has_one_new_sample cmd_out, 1
+    data = assert_has_one_new_sample controller_state, 1
+    vel = assert_has_one_new_sample cmd_out, 1
+
+    puts "vel_base.angular #{vel_base.angular[2]}"
+    puts "vel.angular #{vel.angular[2]}"
+    
+    puts "data_base.angular #{data_base.desired_pose.orientation.roll}"
+    puts "data_base.angular #{data_base.desired_pose.orientation.pitch}"
+    puts "data_base.angular #{data_base.desired_pose.orientation.yaw}"
+
+    puts "data.angular #{data.desired_pose.orientation.roll}"
+    puts "data.angular #{data.desired_pose.orientation.pitch}"
+    puts "data.angular #{data.desired_pose.orientation.yaw}"
+
+    assert((data.angular[2] < 0))
+    assert((data_base.angular[2] - data.angular[2]) > 0.01)
+  end
 end

--- a/test/visp::Task.yml
+++ b/test/visp::Task.yml
@@ -26,15 +26,15 @@ camera_parameters:
   ex: .nan
   ey: .nan
   fisheye: false
-# Defines the controlled degrees of freedom
+ Defines the controlled degrees of freedom
 expected_inputs:
   linear:
   - true 
   - true 
   - true 
   angular:
-  - false 
-  - false
+  - true
+  - true
   - true 
 # Set the gain of the visual controller
 gain: 0.1
@@ -72,7 +72,6 @@ desired_target: 'apriltags_20'
 # in which the robot will perform the visual servoing
 target_list:
  - identifier: 'apriltags_20'
-   rotation_around_z: 0.0
    width: 0.4
    height: 0.4
 # Maximum time in seconds the transformer will wait until it starts dropping samples

--- a/vispTypes.hpp
+++ b/vispTypes.hpp
@@ -79,14 +79,10 @@ namespace visp
      *  targets.
      *  height - object height
      *  width - object width
-     *  rotation_around_z - rotation (in deg)  on the expected input,
-     *                      useful when the corners are not given on
-     *                      the expected default order.
      */
     struct targetObjectParameters
     {
         std::string identifier;
-        double rotation_around_z;
         double width;
         double height;
     };


### PR DESCRIPTION
Visp now requires the full pose as input.

It means the rotation_aroud_z is no longer needed.